### PR TITLE
feat: Google OAuth認証を追加

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,8 +6,26 @@ import { createBrowserClient } from "@/lib/supabase";
 export default function LoginPage() {
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
   const supabase = createBrowserClient();
+
+  const handleGoogleLogin = async () => {
+    setGoogleLoading(true);
+    setMessage(null);
+
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+
+    if (error) {
+      setMessage({ type: "error", text: error.message });
+      setGoogleLoading(false);
+    }
+  };
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -40,42 +58,80 @@ export default function LoginPage() {
           <p className="text-gray-500">家族の成長記録</p>
         </div>
 
-        <form onSubmit={handleLogin} className="bg-white rounded-2xl shadow-sm p-6">
-          <div className="mb-6">
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
-              メールアドレス
-            </label>
-            <input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="example@email.com"
-              required
-              className="w-full px-4 py-3 rounded-xl border border-gray-200 focus:border-mare-300 focus:ring-2 focus:ring-mare-100 outline-none transition-colors"
-            />
+        <div className="bg-white rounded-2xl shadow-sm p-6">
+          <button
+            type="button"
+            onClick={handleGoogleLogin}
+            disabled={googleLoading}
+            className="w-full py-3 bg-white border border-gray-200 hover:bg-gray-50 text-gray-700 font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-3"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24">
+              <path
+                fill="#4285F4"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              />
+              <path
+                fill="#34A853"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="#FBBC05"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              />
+              <path
+                fill="#EA4335"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              />
+            </svg>
+            {googleLoading ? "接続中..." : "Googleでログイン"}
+          </button>
+
+          <div className="relative my-6">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-200"></div>
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-4 bg-white text-gray-400">または</span>
+            </div>
           </div>
 
-          {message && (
-            <div
-              className={`mb-4 p-4 rounded-xl text-sm ${
-                message.type === "success"
-                  ? "bg-kairi-50 text-kairi-500"
-                  : "bg-mare-50 text-mare-500"
-              }`}
-            >
-              {message.text}
+          <form onSubmit={handleLogin}>
+            <div className="mb-4">
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+                メールアドレス
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="example@email.com"
+                required
+                className="w-full px-4 py-3 rounded-xl border border-gray-200 focus:border-mare-300 focus:ring-2 focus:ring-mare-100 outline-none transition-colors"
+              />
             </div>
-          )}
 
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full py-3 bg-mare-400 hover:bg-mare-500 text-white font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {loading ? "送信中..." : "ログインリンクを送信"}
-          </button>
-        </form>
+            {message && (
+              <div
+                className={`mb-4 p-4 rounded-xl text-sm ${
+                  message.type === "success"
+                    ? "bg-kairi-50 text-kairi-500"
+                    : "bg-mare-50 text-mare-500"
+                }`}
+              >
+                {message.text}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-3 bg-mare-400 hover:bg-mare-500 text-white font-medium rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? "送信中..." : "メールでログイン"}
+            </button>
+          </form>
+        </div>
 
         <p className="text-center text-sm text-gray-400 mt-6">
           招待されたメールアドレスでログインできます


### PR DESCRIPTION
## Summary

- ログインページにGoogleログインボタンを追加
- メール認証（Magic Link）と併用可能なUI設計
- Supabase無料プランのメール送信制限（1時間4通）を回避

## あなたがやること

### 1. Supabaseで Google Provider を有効化

1. Supabase Dashboard → Authentication → Providers → Google
2. Google Cloud Consoleで OAuth 2.0 Client ID を作成
3. Client ID と Client Secret を Supabase に設定

### 2. Google Cloud Console設定

**承認済みリダイレクトURI:**
```
https://zgalehrxurddduyxxhsw.supabase.co/auth/v1/callback
```

### 3. Supabase URL Configuration

Redirect URLs に追加:
```
https://sprout.vercel.app/auth/callback
```

## Test plan

- [ ] Googleログインボタンをクリックして認証フローが開始される
- [ ] 認証後、正しくリダイレクトされる
- [ ] メールログインも引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)