### PR TITLE
[monthly-record] 1.1 growth_milestones テーブルを追加

### DIFF
--- a/supabase/migrations/002_growth_milestones.sql
+++ b/supabase/migrations/002_growth_milestones.sql
@@ -1,0 +1,38 @@
+-- =============================================
+-- Growth Milestones Table for Monthly Record Feature
+-- =============================================
+
+-- growth_milestones: 成長メモ（できるようになったこと）
+CREATE TABLE growth_milestones (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  child_id UUID NOT NULL REFERENCES children(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  recorded_at DATE NOT NULL,  -- 月を表す（YYYY-MM-01 形式）
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- =============================================
+-- Indexes
+-- =============================================
+-- 月別取得を高速化するための複合インデックス
+CREATE INDEX idx_growth_milestones_child_month ON growth_milestones(child_id, recorded_at);
+
+-- =============================================
+-- Row Level Security (RLS)
+-- =============================================
+ALTER TABLE growth_milestones ENABLE ROW LEVEL SECURITY;
+
+-- 認証ユーザーのみ閲覧可能
+CREATE POLICY "Authenticated users can view growth_milestones"
+  ON growth_milestones FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+-- 認証ユーザーは作成可能
+CREATE POLICY "Authenticated users can create growth_milestones"
+  ON growth_milestones FOR INSERT
+  WITH CHECK (auth.role() = 'authenticated');
+
+-- 認証ユーザーは削除可能
+CREATE POLICY "Authenticated users can delete growth_milestones"
+  ON growth_milestones FOR DELETE
+  USING (auth.role() = 'authenticated');


### PR DESCRIPTION
## Summary
- 成長メモ（できるようになったこと）を保存する `growth_milestones` テーブルを追加
- 月別取得用の複合インデックス `idx_growth_milestones_child_month` を追加
- RLS ポリシー設定（認証ユーザーのみアクセス可能）

## Changes
- `supabase/migrations/002_growth_milestones.sql` を追加

## Test plan
- [ ] Supabase に migration を適用してテーブルが作成されることを確認
- [ ] RLS ポリシーが正しく動作することを確認

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)