### PR TITLE
[monthly-record] 3.1-3.3 成長メモ API を追加

### DIFF
--- a/src/app/api/growth-milestones/[id]/route.ts
+++ b/src/app/api/growth-milestones/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+type RouteParams = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  // UUID バリデーション
+  const uuidRegex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!uuidRegex.test(id)) {
+    return NextResponse.json({ error: "Invalid milestone ID" }, { status: 400 });
+  }
+
+  // 存在確認
+  const { data: existing, error: fetchError } = await supabase
+    .from("growth_milestones")
+    .select("id")
+    .eq("id", id)
+    .single();
+
+  if (fetchError || !existing) {
+    return NextResponse.json({ error: "Milestone not found" }, { status: 404 });
+  }
+
+  // 削除
+  const { error: deleteError } = await supabase
+    .from("growth_milestones")
+    .delete()
+    .eq("id", id);
+
+  if (deleteError) {
+    console.error("Milestone deletion error:", deleteError);
+    return NextResponse.json(
+      { error: "Failed to delete milestone" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/growth-milestones/route.ts
+++ b/src/app/api/growth-milestones/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const childId = searchParams.get("child_id");
+  const month = searchParams.get("month"); // YYYY-MM 形式
+
+  let query = supabase
+    .from("growth_milestones")
+    .select("id, content, child_id, recorded_at, created_at")
+    .order("created_at", { ascending: false });
+
+  if (childId) {
+    query = query.eq("child_id", childId);
+  }
+
+  if (month) {
+    // YYYY-MM を YYYY-MM-01 形式に変換
+    const recordedAt = `${month}-01`;
+    query = query.eq("recorded_at", recordedAt);
+  }
+
+  const { data: milestones, error } = await query;
+
+  if (error) {
+    console.error("Milestones fetch error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch milestones" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ milestones });
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { child_id, content, recorded_at } = body;
+
+  // バリデーション
+  if (!child_id || !content || !recorded_at) {
+    return NextResponse.json(
+      { error: "Missing required fields: child_id, content, recorded_at" },
+      { status: 400 }
+    );
+  }
+
+  if (typeof content !== "string" || content.trim().length === 0) {
+    return NextResponse.json(
+      { error: "Content must be a non-empty string" },
+      { status: 400 }
+    );
+  }
+
+  // recorded_at を YYYY-MM-01 形式に正規化
+  let normalizedRecordedAt = recorded_at;
+  if (/^\d{4}-\d{2}$/.test(recorded_at)) {
+    normalizedRecordedAt = `${recorded_at}-01`;
+  }
+
+  const { data: milestone, error } = await supabase
+    .from("growth_milestones")
+    .insert({
+      child_id: child_id as string,
+      content: content.trim() as string,
+      recorded_at: normalizedRecordedAt as string,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Milestone creation error:", error);
+    return NextResponse.json(
+      { error: "Failed to create milestone" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ milestone }, { status: 201 });
+}


### PR DESCRIPTION
## Summary
- `GET /api/growth-milestones` - 成長メモ取得（child_id, month でフィルタリング対応）
- `POST /api/growth-milestones` - 成長メモ作成
- `DELETE /api/growth-milestones/[id]` - 成長メモ削除

## Changes
- `src/app/api/growth-milestones/route.ts` を追加
- `src/app/api/growth-milestones/[id]/route.ts` を追加

## Test plan
- [ ] GET API が正しくデータを返すことを確認
- [ ] POST API で新規メモを作成できることを確認
- [ ] DELETE API でメモを削除できることを確認
- [ ] 認証なしでアクセスすると 401 が返ることを確認

Closes #24, #25, #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)