### PR TITLE
feat: BottomNavに「月の記録」タブを追加 (#35)

### DIFF
--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -8,6 +8,7 @@ import { transitions } from "@/lib/animations";
 const navItems = [
   { href: "/", label: "ホーム", icon: HomeIcon },
   { href: "/upload", label: "投稿", icon: PlusIcon },
+  { href: "/monthly", label: "月の記録", icon: CalendarIcon },
   { href: "/growth", label: "成長記録", icon: ChartIcon },
   { href: "/settings", label: "設定", icon: SettingsIcon },
 ];
@@ -129,6 +130,14 @@ function SettingsIcon({ className }: { className?: string }) {
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
       <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+    </svg>
+  );
+}
+
+function CalendarIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- navItems 配列に「月の記録」を追加（投稿と成長記録の間）
- CalendarIcon を新規作成
- /monthly へのリンクを設定

Closes #35

## Test plan
- [ ] ナビゲーションに「月の記録」タブが表示されることを確認
- [ ] タップで /monthly に遷移することを確認
- [ ] アクティブ状態の表示が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)