### PR TITLE
fix: 月の記録ページの問題を修正

### DIFF
--- a/src/app/api/monthly/[year]/[month]/route.ts
+++ b/src/app/api/monthly/[year]/[month]/route.ts
@@ -85,11 +85,16 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     // 成長記録を取得（最新の1件）
+    // 月の最終日を正確に計算
+    const lastDayOfMonth = new Date(yearNum, monthNum, 0).getDate();
+    const monthStart = `${yearNum}-${String(monthNum).padStart(2, "0")}-01`;
+    const monthEnd = `${yearNum}-${String(monthNum).padStart(2, "0")}-${String(lastDayOfMonth).padStart(2, "0")}`;
+
     let growthQuery = supabase
       .from("growth_records")
       .select("height, weight, recorded_at")
-      .gte("recorded_at", `${yearNum}-${String(monthNum).padStart(2, "0")}-01`)
-      .lte("recorded_at", `${yearNum}-${String(monthNum).padStart(2, "0")}-31`)
+      .gte("recorded_at", monthStart)
+      .lte("recorded_at", monthEnd)
       .order("recorded_at", { ascending: false })
       .limit(1);
 

--- a/src/app/monthly/page.tsx
+++ b/src/app/monthly/page.tsx
@@ -170,7 +170,7 @@ export default function MonthlyPage() {
     <AuthGuard>
       <div className="min-h-screen bg-cream-50">
         <Header />
-        <main className="pt-14 pb-20 px-4">
+        <main className="pt-14 pb-32 px-4">
           <div className="max-w-lg mx-auto py-4">
             <h1 className="text-xl font-bold text-gray-800 mb-4">月の記録</h1>
 


### PR DESCRIPTION
## Summary
- ボトムバーとの被りを解消（pb-20 → pb-32に変更）
- 成長記録の月別フィルタで月末日を正確に計算するよう修正

## Test plan
- [ ] 「できるようになったこと」の追加ボタンがボトムバーに被らないことを確認
- [ ] 登録済みの成長記録が月の記録ページに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)