### PR TITLE
refactor: APIルートのビジネスロジックをlib関数に委譲し、TDD体制を整備

### DIFF
--- a/src/app/api/featured/[year]/[month]/route.ts
+++ b/src/app/api/featured/[year]/[month]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { selectFeaturedPost, toFeaturedResponse } from "@/lib/api/featured";
+import { validateYearMonth, calculateMonthRange } from "@/lib/api/date-utils";
 
 type RouteParams = {
   params: Promise<{
@@ -24,29 +26,17 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   const { searchParams } = new URL(request.url);
   const childId = searchParams.get("child_id");
 
-  // 年月のバリデーション
   const yearNum = parseInt(year, 10);
   const monthNum = parseInt(month, 10);
 
-  if (
-    isNaN(yearNum) ||
-    isNaN(monthNum) ||
-    monthNum < 1 ||
-    monthNum > 12 ||
-    yearNum < 2000 ||
-    yearNum > 2100
-  ) {
+  if (!validateYearMonth(yearNum, monthNum)) {
     return NextResponse.json(
       { error: "Invalid year or month" },
       { status: 400 }
     );
   }
 
-  // 月の開始日と終了日を計算
-  const startDate = new Date(yearNum, monthNum - 1, 1);
-  const endDate = new Date(yearNum, monthNum, 0, 23, 59, 59, 999);
-  const startDateStr = startDate.toISOString();
-  const endDateStr = endDate.toISOString();
+  const { startDate: startDateStr, endDate: endDateStr } = calculateMonthRange(yearNum, monthNum);
 
   try {
     // Like数が最も多い画像を取得するクエリ
@@ -98,38 +88,26 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
           .select("*", { count: "exact", head: true })
           .eq("post_id", post.id);
 
+        const child = post.child as { id: string; name: string };
         return {
-          ...post,
+          id: post.id,
+          media_url: post.media_url,
+          created_at: post.created_at,
+          child,
           reactionCount: count ?? 0,
         };
       })
     );
 
-    // リアクション数でソート（多い順）、同数なら新しい順
-    postsWithReactions.sort((a, b) => {
-      if (b.reactionCount !== a.reactionCount) {
-        return b.reactionCount - a.reactionCount;
-      }
-      return (
-        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      );
-    });
-
-    const featured = postsWithReactions[0];
-    const child = featured.child as { id: string; name: string };
+    // lib関数で代表画像を選出
+    const featured = selectFeaturedPost(postsWithReactions);
+    if (!featured) {
+      return NextResponse.json({ featured: null });
+    }
 
     // キャッシュヘッダーを設定（60秒間キャッシュ、stale-while-revalidate）
     return NextResponse.json(
-      {
-        featured: {
-          id: featured.id,
-          mediaUrl: featured.media_url,
-          childId: child.id,
-          childName: child.name,
-          createdAt: featured.created_at,
-          reactionCount: featured.reactionCount,
-        },
-      },
+      { featured: toFeaturedResponse(featured) },
       {
         headers: {
           "Cache-Control": "private, max-age=60, stale-while-revalidate=300",

--- a/src/app/api/monthly/[year]/[month]/route.ts
+++ b/src/app/api/monthly/[year]/[month]/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import {
+  validateYearMonth,
+  calculateMonthRange,
+  calculateMonthDateRange,
+} from "@/lib/api/date-utils";
 
 type RouteParams = {
   params: Promise<{
@@ -24,32 +29,21 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   const { searchParams } = new URL(request.url);
   const childId = searchParams.get("child_id");
 
-  // 年月のバリデーション
   const yearNum = parseInt(year, 10);
   const monthNum = parseInt(month, 10);
 
-  if (
-    isNaN(yearNum) ||
-    isNaN(monthNum) ||
-    monthNum < 1 ||
-    monthNum > 12 ||
-    yearNum < 2000 ||
-    yearNum > 2100
-  ) {
+  if (!validateYearMonth(yearNum, monthNum)) {
     return NextResponse.json(
       { error: "Invalid year or month" },
       { status: 400 }
     );
   }
 
-  // 月の開始日と終了日を計算
-  const startDate = new Date(yearNum, monthNum - 1, 1);
-  const endDate = new Date(yearNum, monthNum, 0, 23, 59, 59, 999);
-  const startDateStr = startDate.toISOString();
-  const endDateStr = endDate.toISOString();
+  const { startDate: startDateStr, endDate: endDateStr } = calculateMonthRange(yearNum, monthNum);
+  const { monthStart, monthEnd } = calculateMonthDateRange(yearNum, monthNum);
 
   // recorded_at 用の月を表す日付（YYYY-MM-01）
-  const recordedAtMonth = `${yearNum}-${String(monthNum).padStart(2, "0")}-01`;
+  const recordedAtMonth = monthStart;
 
   try {
     // 写真を取得（posts テーブルから）
@@ -86,10 +80,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
     // 成長記録を取得（最新の1件）
     // DATE型なので gte/lte で日付範囲比較
-    const monthStart = `${yearNum}-${String(monthNum).padStart(2, "0")}-01`;
-    const lastDay = new Date(yearNum, monthNum, 0).getDate();
-    const monthEnd = `${yearNum}-${String(monthNum).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
-
     let growthQuery = supabase
       .from("growth_records")
       .select("height, weight, recorded_at")

--- a/src/app/api/years/route.ts
+++ b/src/app/api/years/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { groupPostsByYear, selectYearThumbnails } from "@/lib/api/years";
 
 export async function GET(request: NextRequest) {
   const supabase = await createClient();
@@ -48,62 +49,20 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // 年ごとにグループ化
-    const yearMap = new Map<
-      number,
-      { posts: typeof posts; photoCount: number }
-    >();
+    // lib関数で年ごとにグループ化
+    const yearMap = groupPostsByYear(posts);
 
-    for (const post of posts) {
-      const year = new Date(post.created_at).getFullYear();
-      if (!yearMap.has(year)) {
-        yearMap.set(year, { posts: [], photoCount: 0 });
+    // lib関数で各年の代表サムネイルを選出
+    const yearsWithThumbnails = await selectYearThumbnails(
+      yearMap,
+      async (postId) => {
+        const { count } = await supabase
+          .from("reactions")
+          .select("*", { count: "exact", head: true })
+          .eq("post_id", postId);
+        return count ?? 0;
       }
-      const yearData = yearMap.get(year)!;
-      yearData.posts.push(post);
-      yearData.photoCount++;
-    }
-
-    // 各年の代表サムネイル（年内で最もLike数が多い画像）を取得
-    const yearsWithThumbnails = await Promise.all(
-      Array.from(yearMap.entries()).map(async ([year, data]) => {
-        // 各投稿のリアクション数を取得
-        const postsWithReactions = await Promise.all(
-          data.posts.map(async (post) => {
-            const { count } = await supabase
-              .from("reactions")
-              .select("*", { count: "exact", head: true })
-              .eq("post_id", post.id);
-
-            return {
-              ...post,
-              reactionCount: count ?? 0,
-            };
-          })
-        );
-
-        // リアクション数でソート（多い順）、同数なら新しい順
-        postsWithReactions.sort((a, b) => {
-          if (b.reactionCount !== a.reactionCount) {
-            return b.reactionCount - a.reactionCount;
-          }
-          return (
-            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-          );
-        });
-
-        const thumbnail = postsWithReactions[0];
-
-        return {
-          year,
-          thumbnailUrl: thumbnail?.media_url ?? null,
-          photoCount: data.photoCount,
-        };
-      })
     );
-
-    // 年の降順でソート
-    yearsWithThumbnails.sort((a, b) => b.year - a.year);
 
     // キャッシュヘッダーを設定（5分間キャッシュ、stale-while-revalidate）
     return NextResponse.json(

--- a/src/lib/api/date-utils.test.ts
+++ b/src/lib/api/date-utils.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateYearMonth,
+  calculateMonthRange,
+  calculateMonthDateRange,
+} from "./date-utils";
+
+describe("validateYearMonth", () => {
+  describe("正常系", () => {
+    it("有効な年月を受け入れる", () => {
+      expect(validateYearMonth(2024, 1)).toBe(true);
+      expect(validateYearMonth(2024, 12)).toBe(true);
+      expect(validateYearMonth(2000, 6)).toBe(true);
+      expect(validateYearMonth(2100, 6)).toBe(true);
+    });
+  });
+
+  describe("境界値", () => {
+    it("2000年は有効", () => {
+      expect(validateYearMonth(2000, 1)).toBe(true);
+    });
+
+    it("2100年は有効", () => {
+      expect(validateYearMonth(2100, 12)).toBe(true);
+    });
+
+    it("1月は有効", () => {
+      expect(validateYearMonth(2024, 1)).toBe(true);
+    });
+
+    it("12月は有効", () => {
+      expect(validateYearMonth(2024, 12)).toBe(true);
+    });
+  });
+
+  describe("異常系", () => {
+    it("月が0以下の場合はfalseを返す", () => {
+      expect(validateYearMonth(2024, 0)).toBe(false);
+      expect(validateYearMonth(2024, -1)).toBe(false);
+    });
+
+    it("月が13以上の場合はfalseを返す", () => {
+      expect(validateYearMonth(2024, 13)).toBe(false);
+      expect(validateYearMonth(2024, 100)).toBe(false);
+    });
+
+    it("年が1999以下の場合はfalseを返す", () => {
+      expect(validateYearMonth(1999, 6)).toBe(false);
+      expect(validateYearMonth(1000, 6)).toBe(false);
+    });
+
+    it("年が2101以上の場合はfalseを返す", () => {
+      expect(validateYearMonth(2101, 6)).toBe(false);
+    });
+
+    it("NaNの場合はfalseを返す", () => {
+      expect(validateYearMonth(NaN, 6)).toBe(false);
+      expect(validateYearMonth(2024, NaN)).toBe(false);
+    });
+  });
+});
+
+describe("calculateMonthRange", () => {
+  describe("正常系", () => {
+    it("月の開始日と終了日をISO文字列で返す", () => {
+      const range = calculateMonthRange(2024, 1);
+      expect(range.startDate).toBe("2024-01-01T00:00:00.000Z");
+    });
+
+    it("月末日を正しく計算する（31日の月）", () => {
+      const range = calculateMonthRange(2024, 1); // 1月は31日
+      const endDate = new Date(range.endDate);
+      expect(endDate.getUTCDate()).toBe(31);
+    });
+
+    it("月末日を正しく計算する（30日の月）", () => {
+      const range = calculateMonthRange(2024, 4); // 4月は30日
+      const endDate = new Date(range.endDate);
+      expect(endDate.getUTCDate()).toBe(30);
+    });
+
+    it("うるう年の2月を正しく計算する", () => {
+      const range = calculateMonthRange(2024, 2); // 2024年はうるう年
+      const endDate = new Date(range.endDate);
+      expect(endDate.getUTCDate()).toBe(29);
+    });
+
+    it("うるう年でない2月を正しく計算する", () => {
+      const range = calculateMonthRange(2023, 2); // 2023年は平年
+      const endDate = new Date(range.endDate);
+      expect(endDate.getUTCDate()).toBe(28);
+    });
+  });
+});
+
+describe("calculateMonthDateRange", () => {
+  describe("正常系", () => {
+    it("月のYYYY-MM-DD形式の開始日と終了日を返す", () => {
+      const range = calculateMonthDateRange(2024, 3);
+      expect(range.monthStart).toBe("2024-03-01");
+      expect(range.monthEnd).toBe("2024-03-31");
+    });
+
+    it("月が1桁の場合は0埋めする", () => {
+      const range = calculateMonthDateRange(2024, 1);
+      expect(range.monthStart).toBe("2024-01-01");
+    });
+
+    it("2月の終了日を正しく計算する", () => {
+      const range = calculateMonthDateRange(2024, 2); // うるう年
+      expect(range.monthEnd).toBe("2024-02-29");
+    });
+  });
+});

--- a/src/lib/api/date-utils.ts
+++ b/src/lib/api/date-utils.ts
@@ -1,0 +1,50 @@
+export interface MonthISORange {
+  startDate: string;
+  endDate: string;
+}
+
+export interface MonthDateRange {
+  monthStart: string;
+  monthEnd: string;
+}
+
+/**
+ * 年月の妥当性を検証する
+ * @param year 年（2000〜2100が有効）
+ * @param month 月（1〜12が有効）
+ * @returns 有効な場合はtrue
+ */
+export function validateYearMonth(year: number, month: number): boolean {
+  if (isNaN(year) || isNaN(month)) return false;
+  if (month < 1 || month > 12) return false;
+  if (year < 2000 || year > 2100) return false;
+  return true;
+}
+
+/**
+ * 月の開始日時と終了日時をISO文字列で返す
+ * Supabaseのcreated_at (timestamptz) フィールドのフィルタに使用
+ */
+export function calculateMonthRange(year: number, month: number): MonthISORange {
+  const startDate = new Date(Date.UTC(year, month - 1, 1));
+  const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const endDate = new Date(Date.UTC(year, month - 1, lastDay, 23, 59, 59, 999));
+  return {
+    startDate: startDate.toISOString(),
+    endDate: endDate.toISOString(),
+  };
+}
+
+/**
+ * 月の開始日と終了日をYYYY-MM-DD形式で返す
+ * Supabaseのrecorded_at (date) フィールドのフィルタに使用
+ */
+export function calculateMonthDateRange(year: number, month: number): MonthDateRange {
+  const mm = String(month).padStart(2, "0");
+  const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const dd = String(lastDay).padStart(2, "0");
+  return {
+    monthStart: `${year}-${mm}-01`,
+    monthEnd: `${year}-${mm}-${dd}`,
+  };
+}


### PR DESCRIPTION
- 日付バリデーション・月範囲計算の純粋関数をdate-utils.tsに抽出し18件のテストを追加
- featured APIルートがselectFeaturedPost/toFeaturedResponse/validateYearMonth/calculateMonthRangeを使用するよう変更
- years APIルートがgroupPostsByYear/selectYearThumbnailsを使用するよう変更（重複した70行のロジックを削除）
- monthly APIルートがvalidateYearMonth/calculateMonthRange/calculateMonthDateRangeを使用するよう変更

テスト: 69件→87件（+18件）、全テストパス

https://claude.ai/code/session_01UodjiCwkW5vRqPhhMQzw6k