### PR TITLE
chore: add codex app-server helpers

### DIFF
--- a/docs/codex-app-server.md
+++ b/docs/codex-app-server.md
@@ -1,0 +1,85 @@
+# Codex App Server
+
+Codex App Server is a local interface for custom Codex clients. It is useful for
+deep development integrations that need Codex threads, turns, approvals, and
+streamed agent events. It is not part of the Sprout production app.
+
+## Prerequisites
+
+- Codex CLI is installed and authenticated.
+- `codex doctor` passes in the local developer environment.
+- This repository is trusted by Codex so `.codex/config.toml` and `AGENTS.md`
+  are loaded.
+
+## Commands
+
+Start a foreground stdio app server for custom clients:
+
+```bash
+npm run codex:app-server
+```
+
+Start a foreground app server on Codex's default Unix socket:
+
+```bash
+npm run codex:app-server:unix
+```
+
+Start a foreground app server on a localhost WebSocket for local experiments:
+
+```bash
+npm run codex:app-server:ws:local
+```
+
+Generate TypeScript protocol bindings for the installed Codex CLI version:
+
+```bash
+npm run codex:app-server:schema
+```
+
+Generated schema files are written to `/tmp/sprout-codex-app-server-schema`.
+They are version-specific diagnostics and should not be committed by default.
+
+## Optional Daemon
+
+`codex app-server daemon` requires the standalone Codex install managed by the
+Codex installer. A Homebrew-only Codex install can run foreground app-server
+commands, but daemon start will fail until the standalone install exists.
+
+After installing the standalone Codex package, daemon commands can be run
+directly:
+
+```bash
+codex app-server daemon start
+codex app-server daemon version
+codex app-server proxy
+codex app-server daemon stop
+```
+
+## Client Flow
+
+Clients connect to the selected transport and then:
+
+1. Send `initialize` with client metadata.
+2. Send the `initialized` notification.
+3. Start or resume a thread.
+4. Start a turn with `cwd` set to this repository when the task should operate
+   on Sprout.
+5. Read streamed notifications until `turn/completed`.
+
+## Transport Notes
+
+- The default app-server transport is stdio.
+- `npm run codex:app-server:unix` exposes Codex's default local Unix socket
+  while the foreground process is running.
+- WebSocket transport is experimental. Keep it on `127.0.0.1` for local
+  experiments, and configure WebSocket authentication before any remote or
+  non-loopback exposure.
+
+## Safety
+
+- Do not commit app-server tokens, generated credentials, local sockets, logs,
+  or machine-specific daemon state.
+- Keep model provider, authentication, and telemetry settings in the developer's
+  user-level Codex config unless the team explicitly decides otherwise.
+- Use the Codex SDK instead of app-server for CI or batch automation.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "codex:app-server": "codex app-server",
+    "codex:app-server:unix": "codex app-server --listen unix://",
+    "codex:app-server:ws:local": "codex app-server --listen ws://127.0.0.1:4500",
+    "codex:app-server:schema": "codex app-server generate-ts --out /tmp/sprout-codex-app-server-schema"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.958.0",


### PR DESCRIPTION
## Summary
- Add npm helpers for foreground Codex App Server usage
- Document local stdio, Unix socket, localhost WebSocket, and schema generation workflows
- Call out that daemon mode requires the standalone Codex install and is optional

## Validation
- node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"
- npm run codex:app-server:schema
- npm run codex:app-server:ws:local started successfully on 127.0.0.1:4500
- GET /readyz and GET /healthz returned HTTP 200 during the local app-server check

## Notes
- This PR is based on current main after #84 was merged.
- The generated TypeScript schema is written to /tmp/sprout-codex-app-server-schema and is not committed.